### PR TITLE
feat(oauth): 支持 OAuth 回调 URI 持久化与管理，管理面板可创建/编辑回调 URI；在 Authorize 中对 r…

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -29,6 +29,12 @@ func SetInitValue() {
 	viper.SetDefault("oauth2.server.access_secret", uuid.New().String())
 	viper.SetDefault("oauth2.server.ak_expire", 3600*24*14)
 
+	// cookie / auth
+	// 开发时默认允许非 Secure，以便本地调试；生产请通过配置或环境覆盖为安全值
+	viper.SetDefault("auth.cookie.secure", false)
+	viper.SetDefault("auth.cookie.samesite", "Lax")
+	viper.SetDefault("auth.cookie.httponly", true)
+
 	// 服务token
 	viper.SetDefault("service.token", "campux123456")
 	viper.SetDefault("service.bots", []int64{123456789})

--- a/backend/controller/accapi.go
+++ b/backend/controller/accapi.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/RockChinQ/Campux/backend/database"
 	"github.com/RockChinQ/Campux/backend/service"
@@ -86,37 +87,31 @@ func (ar *AccountRouter) LoginAccount(c *gin.Context) {
 		return
 	}
 
-	domain := c.Request.Header.Get("Origin")
+	// 使用配置控制 cookie 的安全策略
+	secure := viper.GetBool("auth.cookie.secure")
+	sameSiteStr := viper.GetString("auth.cookie.samesite")
+	httpOnly := viper.GetBool("auth.cookie.httponly")
 
-	// set-cookie
-	// 要求：
-	// 1. 调试模式时允许跨域
-	// 2. 设置的域为请求的域
-	// 3. 允许js修改
-	if gin.Mode() == gin.DebugMode {
-		http.SetCookie(c.Writer, &http.Cookie{
-			Name:     "access-token",
-			Value:    token,
-			Path:     "/",
-			Domain:   domain,
-			Secure:   true,
-			SameSite: http.SameSiteNoneMode,
-			HttpOnly: false,
-			MaxAge:   viper.GetInt("auth.jwt.expire"),
-		})
-	} else {
-		// 正式环境用strict模式
-		http.SetCookie(c.Writer, &http.Cookie{
-			Name:     "access-token",
-			Value:    token,
-			Path:     "/",
-			Domain:   domain,
-			Secure:   false,
-			SameSite: http.SameSiteStrictMode,
-			HttpOnly: false,
-			MaxAge:   viper.GetInt("auth.jwt.expire"),
-		})
+	var sameSiteMode http.SameSite
+	switch strings.ToLower(sameSiteStr) {
+	case "none":
+		sameSiteMode = http.SameSiteNoneMode
+	case "strict":
+		sameSiteMode = http.SameSiteStrictMode
+	default:
+		sameSiteMode = http.SameSiteLaxMode
 	}
+
+	http.SetCookie(c.Writer, &http.Cookie{
+		Name:  "access-token",
+		Value: token,
+		Path:  "/",
+		// Domain:   "campux.com", // 可在配置中启用
+		Secure:   secure,
+		SameSite: sameSiteMode,
+		HttpOnly: httpOnly,
+		MaxAge:   viper.GetInt("auth.jwt.expire"),
+	})
 
 	ar.Success(c, gin.H{
 		"token": token,

--- a/backend/controller/admapi.go
+++ b/backend/controller/admapi.go
@@ -22,6 +22,7 @@ func NewAdminRouter(rg *gin.RouterGroup, as service.AdminService, acs service.Ac
 
 	// bind routes
 	group.POST("/add-oauth2-app", ar.AddOAuth2App)
+	group.PUT("/update-oauth2-app", ar.UpdateOAuth2App)
 	group.GET("/get-oauth2-apps", ar.GetOAuth2AppList)
 	group.DELETE("/del-oauth2-app/:id", ar.DeleteOAuth2App)
 	group.GET("/init", ar.IsInit)
@@ -54,8 +55,8 @@ func (ar *AdminRouter) AddOAuth2App(c *gin.Context) {
 		return
 	}
 
-	// 创建OAuth2应用
-	app, err := ar.AdminService.AddOAuth2App(body.Name, body.Emoji)
+	// 创建OAuth2应用（包含回调地址）
+	app, err := ar.AdminService.AddOAuth2App(body.Name, body.Emoji, body.RedirectURIs)
 
 	if err != nil {
 		ar.Fail(c, 2, err.Error())
@@ -63,6 +64,36 @@ func (ar *AdminRouter) AddOAuth2App(c *gin.Context) {
 	}
 
 	ar.Success(c, app)
+}
+
+// 更新 OAuth2 应用（回调地址）
+func (ar *AdminRouter) UpdateOAuth2App(c *gin.Context) {
+	uin, err := ar.Auth(c, UserOnly)
+
+	if err != nil {
+		return
+	}
+
+	if !ar.AdminService.CheckUserGroup(uin, []database.UserGroup{
+		database.USER_GROUP_ADMIN,
+	}) {
+		ar.StatusCode(c, 401, "权限不足")
+		return
+	}
+
+	var body OAuth2AppUpdateBody
+
+	if err := c.ShouldBindJSON(&body); err != nil {
+		ar.Fail(c, 1, err.Error())
+		return
+	}
+
+	if err := ar.AdminService.UpdateOAuth2App(body.ClientID, body.RedirectURIs); err != nil {
+		ar.Fail(c, 2, err.Error())
+		return
+	}
+
+	ar.Success(c, nil)
 }
 
 // 获取 OAuth2 应用列表

--- a/backend/controller/dto.go
+++ b/backend/controller/dto.go
@@ -158,6 +158,14 @@ type OAuth2AppCreateBody struct {
 
 	// emoji
 	Emoji string `json:"emoji" binding:"required"`
+
+	// 回调地址列表
+	RedirectURIs []string `json:"redirect_uris"`
+}
+
+type OAuth2AppUpdateBody struct {
+	ClientID     string   `json:"client_id" binding:"required"`
+	RedirectURIs []string `json:"redirect_uris" binding:"required"`
 }
 
 type OAuth2AuthorizeBody struct {

--- a/backend/controller/oauthapi.go
+++ b/backend/controller/oauthapi.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/RockChinQ/Campux/backend/service"
@@ -58,43 +59,75 @@ func (oar *OAuth2Router) GetOAuth2AppInfo(c *gin.Context) {
 
 func (oar *OAuth2Router) Authorize(c *gin.Context) {
 
-	uin, err := oar.Auth(c, UserOnly)
-
-	if err != nil {
-		return
-	}
-
+	// 获取参数
 	clientID := c.Query("client_id")
+	redirectURI := c.Query("redirect_uri")
 
 	if clientID == "" {
 		oar.Fail(c, 1, "未提供 client_id")
 		return
 	}
 
+	if redirectURI == "" {
+		oar.Fail(c, 1, "未提供 redirect_uri")
+		return
+	}
+
 	// 检查是否存在这个应用
 	app, err := oar.OAuth2Service.GetOAuth2AppByClientID(clientID)
-
 	if err != nil {
 		oar.Fail(c, 2, err.Error())
 		return
 	}
-
 	if app == nil {
 		oar.Fail(c, 3, "此应用未注册")
 		return
 	}
 
-	// 计算code
-	code, err := oar.OAuth2Service.GenerateCode(app.ClientID, uin)
+	// 检查登录
+	uin, err := oar.Auth(c, UserOnly)
+	if err != nil {
+		// 未登录，重定向到 Campux 登录页，登录后回跳本 authorize
+		loginURL := "/login?redirect=" + url.QueryEscape(c.Request.RequestURI)
+		c.Redirect(http.StatusFound, loginURL)
+		return
+	}
 
+	// 生成授权码
+	code, err := oar.OAuth2Service.GenerateCode(app.ClientID, uin)
 	if err != nil {
 		oar.Fail(c, 4, err.Error())
 		return
 	}
 
-	oar.Success(c, gin.H{
-		"code": code,
-	})
+	// 基本校验 redirect_uri（应在未来改为与注册回调地址精准匹配）
+	parsed, perr := url.Parse(redirectURI)
+	if perr != nil || (parsed.Scheme != "http" && parsed.Scheme != "https") || parsed.Host == "" {
+		oar.Fail(c, 5, "invalid redirect_uri")
+		return
+	}
+
+	// 严格匹配已注册回调地址，防止 open redirect
+	matched := false
+	for _, ru := range app.RedirectURIs {
+		if ru == redirectURI {
+			matched = true
+			break
+		}
+	}
+
+	if !matched {
+		oar.Fail(c, 6, "redirect_uri not registered for this client")
+		return
+	}
+
+	// 拼接回调地址并重定向（对参数进行编码）
+	sep := "?"
+	if strings.Contains(redirectURI, "?") {
+		sep = "&"
+	}
+	redirectWithCode := redirectURI + sep + "code=" + url.QueryEscape(code) + "&client_id=" + url.QueryEscape(clientID)
+	c.Redirect(http.StatusFound, redirectWithCode)
 }
 
 func (oar *OAuth2Router) GetAccessToken(c *gin.Context) {

--- a/backend/database/base.go
+++ b/backend/database/base.go
@@ -43,4 +43,5 @@ type BaseDBManager interface {
 	GetOAuth2AppByName(name string) (*OAuthAppPO, error)
 	GetOAuth2Apps() ([]OAuthAppPO, error)
 	DeleteOAuth2App(clientID string) error
+	UpdateOAuth2App(clientID string, redirectURIs []string) error
 }

--- a/backend/database/mongo.go
+++ b/backend/database/mongo.go
@@ -603,3 +603,12 @@ func (m *MongoDBManager) DeleteOAuth2App(clientID string) error {
 	_, err := m.Client.Database(viper.GetString("database.mongo.db")).Collection(OAUTH_APP_COLLECTION).DeleteOne(context.TODO(), bson.M{"client_id": clientID})
 	return err
 }
+
+func (m *MongoDBManager) UpdateOAuth2App(clientID string, redirectURIs []string) error {
+	_, err := m.Client.Database(viper.GetString("database.mongo.db")).Collection(OAUTH_APP_COLLECTION).UpdateOne(
+		context.TODO(),
+		bson.M{"client_id": clientID},
+		bson.M{"$set": bson.M{"redirect_uris": redirectURIs}},
+	)
+	return err
+}

--- a/backend/database/po.go
+++ b/backend/database/po.go
@@ -131,9 +131,10 @@ const (
 )
 
 type OAuthAppPO struct {
-	Name         string    `json:"name" bson:"name" gorm:"type:varchar(256)"`                   // 应用名称
-	Emoji        string    `json:"emoji" bson:"emoji" gorm:"type:varchar(16)"`                  // Emoji
-	ClientID     string    `json:"client_id" bson:"client_id" gorm:"type:varchar(256)"`         // 客户端ID
-	ClientSecret string    `json:"client_secret" bson:"client_secret" gorm:"type:varchar(256)"` // 客户端密钥
-	CreatedAt    time.Time `json:"created_at" bson:"created_at" gorm:"autoCreateTime"`          // CST时间
+	Name         string        `json:"name" bson:"name" gorm:"type:varchar(256)"`                   // 应用名称
+	Emoji        string        `json:"emoji" bson:"emoji" gorm:"type:varchar(16)"`                  // Emoji
+	ClientID     string        `json:"client_id" bson:"client_id" gorm:"type:varchar(256)"`         // 客户端ID
+	ClientSecret string        `json:"client_secret" bson:"client_secret" gorm:"type:varchar(256)"` // 客户端密钥
+	RedirectURIs util.StrArray `json:"redirect_uris" bson:"redirect_uris" gorm:"type:text"`         // 回调地址列表
+	CreatedAt    time.Time     `json:"created_at" bson:"created_at" gorm:"autoCreateTime"`          // CST时间
 }

--- a/backend/database/sqlite.go
+++ b/backend/database/sqlite.go
@@ -403,3 +403,7 @@ func (m *SQLiteDBManager) GetOAuth2Apps() ([]OAuthAppPO, error) {
 func (m *SQLiteDBManager) DeleteOAuth2App(clientID string) error {
 	return m.Client.Where("client_id = ?", clientID).Delete(&OAuthAppPO{}).Error
 }
+
+func (m *SQLiteDBManager) UpdateOAuth2App(clientID string, redirectURIs []string) error {
+	return m.Client.Model(&OAuthAppPO{}).Where("client_id = ?", clientID).Update("redirect_uris", util.StrArray(redirectURIs)).Error
+}

--- a/backend/service/admin.go
+++ b/backend/service/admin.go
@@ -18,7 +18,7 @@ func NewAdminService(db database.BaseDBManager) *AdminService {
 	}
 }
 
-func (as *AdminService) AddOAuth2App(name, emoji string) (*database.OAuthAppPO, error) {
+func (as *AdminService) AddOAuth2App(name, emoji string, redirectURIs []string) (*database.OAuthAppPO, error) {
 	check, err := as.DB.GetOAuth2AppByName(name)
 
 	if err != nil {
@@ -34,6 +34,7 @@ func (as *AdminService) AddOAuth2App(name, emoji string) (*database.OAuthAppPO, 
 		Emoji:        emoji,
 		ClientID:     util.RandomString(16),
 		ClientSecret: uuid.New().String(),
+		RedirectURIs: util.StrArray(redirectURIs),
 		CreatedAt:    util.GetCSTTime(),
 	}
 
@@ -49,6 +50,10 @@ func (as *AdminService) GetOAuth2Apps() ([]database.OAuthAppPO, error) {
 // delete
 func (as *AdminService) DeleteOAuth2App(appID string) error {
 	return as.DB.DeleteOAuth2App(appID)
+}
+
+func (as *AdminService) UpdateOAuth2App(clientID string, redirectURIs []string) error {
+	return as.DB.UpdateOAuth2App(clientID, redirectURIs)
 }
 
 func (as *AdminService) IsInit() (bool, error) {

--- a/frontend/src/components/OAuthAppCard.vue
+++ b/frontend/src/components/OAuthAppCard.vue
@@ -10,6 +10,12 @@
                 <p><strong>Client ID: </strong>{{ oauthApp.client_id }}</p>
                 <p><strong>Client Secret: </strong>{{ oauthApp.client_secret }}</p>
             </div>
+            <div id="app-redirects" style="margin-top:8px">
+                <p><strong>Redirect URIs:</strong></p>
+                <ul>
+                    <li v-for="(r, idx) in oauthApp.redirect_uris" :key="idx" style="font-size:0.8rem">{{ r }}</li>
+                </ul>
+            </div>
 
         </div>
 
@@ -17,6 +23,7 @@
 
 
         <v-btn color="red" text @click="deletingDialog = true">删除</v-btn>
+        <v-btn color="primary" text @click="openEdit">编辑回调</v-btn>
         </div>
         
     </v-card>
@@ -33,6 +40,19 @@
             </v-card-actions>
         </v-card>
     </v-dialog>
+
+    <v-dialog v-model="editingDialog" max-width="600">
+        <v-card>
+            <v-card-title>编辑回调地址</v-card-title>
+            <v-card-text>
+                <v-textarea v-model="editRedirectsText" label="回调地址（每行一个）" rows="6"></v-textarea>
+            </v-card-text>
+            <v-card-actions>
+                <v-btn text @click="editingDialog = false">取消</v-btn>
+                <v-btn color="primary" text @click="saveEdit">保存</v-btn>
+            </v-card-actions>
+        </v-card>
+    </v-dialog>
 </template>
 
 <script>
@@ -42,6 +62,8 @@ export default {
     data() {
         return {
             deletingDialog: false,
+            editingDialog: false,
+            editRedirectsText: '',
         }
     },
     mounted() {
@@ -54,6 +76,30 @@ export default {
         deleteApp() {
             this.$emit('deleteApp', this.oauthApp.client_id)
         },
+        openEdit() {
+            this.editRedirectsText = (this.oauthApp.redirect_uris || []).join('\n')
+            this.editingDialog = true
+        },
+        saveEdit() {
+            const payload = {
+                client_id: this.oauthApp.client_id,
+                redirect_uris: this.editRedirectsText.split('\n').map(s => s.trim()).filter(s => s.length > 0)
+            }
+
+            this.$axios.put('/v1/admin/update-oauth2-app', payload)
+                .then(res => {
+                    if (res.data.code === 0) {
+                        this.toast('更新成功', 'success')
+                        this.$emit('refresh')
+                        this.editingDialog = false
+                    } else {
+                        this.toast('更新失败：' + res.data.msg)
+                    }
+                })
+                .catch(err => {
+                    this.toast('更新失败：' + err)
+                })
+        }
     }
 }
 </script>

--- a/frontend/src/pages/admin.vue
+++ b/frontend/src/pages/admin.vue
@@ -86,7 +86,7 @@
                 <div
                     style="overflow-y: scroll; max-height: calc(100vh - 260px); min-height: calc(100vh - 360px);margin-top: 2rem">
                     <OAuthAppCard v-for="o in oauthApps" :key="o.name" :oauthApp="o" style="margin-top: 16px"
-                        @toast="toast" @deleteApp="deleteOAuthApp" />
+                        @toast="toast" @deleteApp="deleteOAuthApp" @refresh="getOAuthApps" />
 
                 </div>
             </div>
@@ -116,6 +116,7 @@
                     <p id="oauth-emoji">{{ newOAuthApp.emoji }}</p>
                     <EmojiPicker id="oauth-emoji-picker" :native="true" @select="onEmojiSelect" />
                 </div>
+                <v-textarea v-model="newOAuthApp.redirect_uris_text" label="回调地址（每行一个）" variant="solo" rows="3"></v-textarea>
             </v-card-text>
             <v-card-actions>
                 <v-btn text @click="showOAuthAppCreateDialog = false">取消</v-btn>
@@ -181,6 +182,7 @@ export default {
             newOAuthApp: {
                 name: '',
                 emoji: '🥰',
+                redirect_uris_text: '',
             },
             metadataList: [],
             metadataListRefreshing: false,
@@ -402,7 +404,15 @@ export default {
                 return
             }
 
-            this.$axios.post('/v1/admin/add-oauth2-app', this.newOAuthApp)
+            // prepare redirect_uris array from textarea
+            let payload = Object.assign({}, this.newOAuthApp)
+            if (payload.redirect_uris_text) {
+                payload.redirect_uris = payload.redirect_uris_text.split('\n').map(s => s.trim()).filter(s => s.length > 0)
+            } else {
+                payload.redirect_uris = []
+            }
+
+            this.$axios.post('/v1/admin/add-oauth2-app', payload)
                 .then(res => {
                     if (res.data.code === 0) {
                         this.toast('创建成功', 'success')


### PR DESCRIPTION
…edirect_uri 做严格匹配并对 code 编码；新增 DB 接口 UpdateOAuth2App 并实现 sqlite/mongo；前端显示与编辑回调 URI；将 cookie 写入逻辑配置化（默认开发友好），并修复登录处 cookie 设置