### PR TITLE
Enhance login feedback and improve image upload handling

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,11 +9,13 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.812.0",
+    "@aws-sdk/lib-storage": "3.1045.0",
     "@campux/config": "workspace:*",
     "@campux/db": "workspace:*",
     "@campux/domain": "workspace:*",
     "@campux/integrations": "workspace:*",
     "@campux/render": "workspace:*",
+    "@fastify/multipart": "^9.0.0",
     "@fastify/cors": "^11.0.1",
     "@fastify/static": "^9.1.3",
     "@fastify/websocket": "^11.2.0",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 import Fastify from "fastify";
 import cors from "@fastify/cors";
+import fastifyMultipart from "@fastify/multipart";
 import fastifyStatic from "@fastify/static";
 import { loadConfig } from "@campux/config";
 import { createRuntimeQueue } from "./runtime/queue";
@@ -30,12 +31,16 @@ const app = Fastify({
   logger: {
     level: config.nodeEnv === "production" ? "info" : "debug",
   },
+  bodyLimit: 15 * 1024 * 1024,
 });
 await runDatabaseMigrations(app.log);
 
 await app.register(cors, {
   origin: config.webOrigin,
   credentials: true,
+});
+await app.register(fastifyMultipart, {
+  limits: { fileSize: 10 * 1024 * 1024, files: 1 },
 });
 
 const queue = createRuntimeQueue({

--- a/apps/server/src/routes/posts.ts
+++ b/apps/server/src/routes/posts.ts
@@ -1,5 +1,8 @@
 import { Buffer } from "node:buffer";
-import { CreateBucketCommand, GetObjectCommand, HeadBucketCommand, PutObjectCommand } from "@aws-sdk/client-s3";
+import { Transform } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import { CreateBucketCommand, GetObjectCommand, HeadBucketCommand } from "@aws-sdk/client-s3";
+import { Upload } from "@aws-sdk/lib-storage";
 import type { FastifyInstance } from "fastify";
 import { z } from "zod";
 import type { CampuxConfig } from "@campux/config";
@@ -11,12 +14,6 @@ import { toPostListItem } from "../lib/posts";
 import { prisma } from "../lib/prisma";
 import { readTenantPendingPostLimit } from "../lib/tenant-metadata";
 import type { OneBotRuntime } from "../runtime/onebot";
-
-const uploadSchema = z.object({
-  fileName: z.string().min(1),
-  contentType: z.string().min(1),
-  base64: z.string().min(1),
-});
 
 const fileQuerySchema = z.object({
   key: z.string().min(1),
@@ -43,6 +40,12 @@ const createPostSchema = z.object({
   ).max(9).default([]),
 });
 
+const legacyUploadSchema = z.object({
+  fileName: z.string().min(1),
+  contentType: z.string().min(1).optional(),
+  base64: z.string().min(1),
+});
+
 class PendingPostLimitError extends Error {
   constructor(
     readonly pendingCount: number,
@@ -52,10 +55,51 @@ class PendingPostLimitError extends Error {
   }
 }
 
-function decodeBase64(base64: string) {
-  const commaIndex = base64.indexOf(",");
-  const payload = commaIndex >= 0 ? base64.slice(commaIndex + 1) : base64;
+function sanitizeUploadExtension(fileName: string | undefined): string {
+  const raw = fileName?.split(".").pop();
+  if (!raw) {
+    return "bin";
+  }
+  return raw.replace(/[^a-zA-Z0-9]/g, "").toLowerCase() || "bin";
+}
+
+const IMAGE_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "image/webp",
+  "image/heic",
+  "image/heif",
+  "image/bmp",
+  "image/tiff",
+  "image/svg+xml",
+]);
+
+function isAllowedImageType(contentType: string): boolean {
+  return IMAGE_MIME_TYPES.has(contentType);
+}
+
+function headerIncludes(value: string | string[] | undefined, expected: string): boolean {
+  return Array.isArray(value) ? value.some((item) => item.includes(expected)) : Boolean(value?.includes(expected));
+}
+
+function readLegacyUploadContentType(value: string, fallback: string | undefined): string {
+  const match = /^data:([^;,]+)[;,]/.exec(value);
+  return fallback || match?.[1] || "application/octet-stream";
+}
+
+function decodeLegacyBase64Upload(value: string): Buffer {
+  const commaIndex = value.indexOf(",");
+  const payload = commaIndex >= 0 ? value.slice(commaIndex + 1) : value;
   return Buffer.from(payload, "base64");
+}
+
+function isUploadTooLargeError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  const code = "code" in error ? String(error.code) : "";
+  return code === "FST_REQ_FILE_TOO_LARGE" || error.message.includes("size limit exceeded") || error.message.includes("File size limit exceeded");
 }
 
 async function ensureBucket(config: CampuxConfig) {
@@ -67,6 +111,40 @@ async function ensureBucket(config: CampuxConfig) {
   }
 
   return s3;
+}
+
+async function uploadImageBytes({
+  config,
+  tenantId,
+  fileName,
+  contentType,
+  body,
+}: {
+  config: CampuxConfig;
+  tenantId: string;
+  fileName: string;
+  contentType: string;
+  body: Buffer | Transform;
+}) {
+  const extension = sanitizeUploadExtension(fileName);
+  const key = `tenants/${tenantId}/uploads/${crypto.randomUUID()}.${extension}`;
+  const s3 = await ensureBucket(config);
+
+  await new Upload({
+    client: s3,
+    params: {
+      Bucket: config.s3.bucket,
+      Key: key,
+      Body: body,
+      ContentType: contentType,
+    },
+  }).done();
+
+  return {
+    key,
+    url: `/api/uploads/post-image?key=${encodeURIComponent(key)}`,
+    fileName,
+  };
 }
 
 function isTransactionSerializationFailure(value: unknown) {
@@ -102,29 +180,88 @@ export function registerPostRoutes(app: FastifyInstance, config: CampuxConfig, o
 
   app.post("/api/uploads/post-images", async (request, reply) => {
     const context = await requireTenantContext(request, reply);
-    const body = uploadSchema.parse(request.body);
-    const bytes = decodeBase64(body.base64);
-    if (bytes.byteLength > 8 * 1024 * 1024) {
-      return reply.code(413).send({ message: "图片不能超过 8MB" });
+    const requestContentType = request.headers["content-type"] ?? "";
+    const maxUploadSize = 10 * 1024 * 1024;
+
+    if (headerIncludes(requestContentType, "application/json")) {
+      const body = legacyUploadSchema.parse(request.body);
+      const contentType = readLegacyUploadContentType(body.base64, body.contentType);
+      if (!isAllowedImageType(contentType)) {
+        return reply.code(400).send({ message: "仅支持图片格式（jpg/png/gif/webp）" });
+      }
+
+      const bytes = decodeLegacyBase64Upload(body.base64);
+      if (bytes.byteLength > maxUploadSize) {
+        return reply.code(413).send({ message: "图片不能超过 10MB" });
+      }
+
+      return uploadImageBytes({
+        config,
+        tenantId: context.selectedTenant.id,
+        fileName: body.fileName,
+        contentType,
+        body: bytes,
+      });
     }
 
-    const extension = body.fileName.split(".").pop()?.replace(/[^a-zA-Z0-9]/g, "").toLowerCase() || "bin";
-    const key = `tenants/${context.selectedTenant.id}/uploads/${crypto.randomUUID()}.${extension}`;
-    const s3 = await ensureBucket(config);
-    await s3.send(
-      new PutObjectCommand({
-        Bucket: config.s3.bucket,
-        Key: key,
-        Body: bytes,
-        ContentType: body.contentType,
-      }),
-    );
+    let file;
+    try {
+      file = await request.file();
+    } catch (error) {
+      if (isUploadTooLargeError(error)) {
+        return reply.code(413).send({ message: "图片不能超过 10MB" });
+      }
+      throw error;
+    }
+    if (!file) {
+      return reply.code(400).send({ message: "请上传图片文件" });
+    }
 
-    return {
-      key,
-      url: `/api/uploads/post-image?key=${encodeURIComponent(key)}`,
-      fileName: body.fileName,
-    };
+    const contentType = file.mimetype || "application/octet-stream";
+    if (!isAllowedImageType(contentType)) {
+      file.file.destroy();
+      return reply.code(400).send({ message: "仅支持图片格式（jpg/png/gif/webp）" });
+    }
+
+    const sourceStream = file.file;
+    let transferredBytes = 0;
+    const limitedStream = new Transform({
+      transform(chunk: Buffer, _encoding, callback) {
+        transferredBytes += chunk.length;
+        if (transferredBytes > maxUploadSize) {
+          callback(new Error("size limit exceeded"));
+          return;
+        }
+        callback(null, chunk);
+      },
+    });
+
+    const uploadPromise = uploadImageBytes({
+      config,
+      tenantId: context.selectedTenant.id,
+      fileName: file.filename ?? `image.${sanitizeUploadExtension(undefined)}`,
+      contentType,
+      body: limitedStream,
+    });
+
+    try {
+      const [result] = await Promise.all([
+        uploadPromise,
+        pipeline(sourceStream, limitedStream),
+      ]);
+      return result;
+    } catch (error: unknown) {
+      if (!limitedStream.destroyed) {
+        limitedStream.destroy();
+      }
+      if (!sourceStream.destroyed) {
+        sourceStream.destroy();
+      }
+      if (isUploadTooLargeError(error)) {
+        return reply.code(413).send({ message: "图片不能超过 10MB" });
+      }
+      return reply.code(500).send({ message: "图片上传失败，请重试" });
+    }
   });
 
   app.post("/api/posts", async (request, reply) => {

--- a/apps/server/src/runtime/publishing.ts
+++ b/apps/server/src/runtime/publishing.ts
@@ -1,5 +1,5 @@
 import type { FastifyBaseLogger } from "fastify";
-import { GetObjectCommand } from "@aws-sdk/client-s3";
+import { GetObjectCommand, HeadObjectCommand } from "@aws-sdk/client-s3";
 import type { CampuxConfig } from "@campux/config";
 import { Prisma } from "@campux/db";
 import type { PostStatus } from "@campux/db";
@@ -458,7 +458,7 @@ async function handlePublishAttempt(queue: RuntimeQueue, logger: FastifyBaseLogg
       anonymous: attempt.post.anonymous,
       authorQq: attempt.post.author.qqUin.toString(),
     });
-    const postImages = await loadPostImages(config, attempt.post.images);
+    const postImages = await loadPostImages(config, attempt.tenantId, attempt.post.images);
     const result = await publishToQZone({
       tenantId: attempt.tenantId,
       postId: attempt.postId,
@@ -841,17 +841,41 @@ function getImageUrls(images: unknown) {
   });
 }
 
-async function loadPostImages(config: CampuxConfig, images: unknown) {
+const IMAGE_READ_SIZE_LIMIT = 10 * 1024 * 1024;
+
+function assertValidImageKey(key: string, tenantId: string): void {
+  const allowedPrefixes = [
+    `tenants/${tenantId}/uploads/`,
+    `tenants/${tenantId}/legacy/`,
+  ];
+  if (!allowedPrefixes.some((prefix) => key.startsWith(prefix))) {
+    throw new Error(`图片 key 不属于当前校园墙：${key}`);
+  }
+}
+
+async function loadPostImages(config: CampuxConfig, tenantId: string, images: unknown) {
   if (!Array.isArray(images)) {
-    return [];
+    throw new Error("稿件图片数据格式错误：images 不是数组");
   }
   const s3 = createS3Client(config);
   const result = [];
   for (const image of images) {
     const candidate = image as ImagePayload;
     if (!candidate.key) {
-      continue;
+      throw new Error("稿件图片数据缺少 key 字段");
     }
+    assertValidImageKey(candidate.key, tenantId);
+
+    const head = await s3.send(
+      new HeadObjectCommand({
+        Bucket: config.s3.bucket,
+        Key: candidate.key,
+      }),
+    );
+    if (head.ContentLength !== undefined && head.ContentLength > IMAGE_READ_SIZE_LIMIT) {
+      throw new Error(`图片 ${candidate.key} 超过 10MB 限制（${Math.round(head.ContentLength / 1024 / 1024)}MB）`);
+    }
+
     const object = await s3.send(
       new GetObjectCommand({
         Bucket: config.s3.bucket,
@@ -860,9 +884,21 @@ async function loadPostImages(config: CampuxConfig, images: unknown) {
     );
     const body = object.Body;
     if (!body || !("transformToByteArray" in body) || typeof body.transformToByteArray !== "function") {
-      continue;
+      throw new Error(`图片 ${candidate.key} 读取失败：对象 Body 不可读`);
     }
-    const bytes = await body.transformToByteArray();
+
+    let bytes: Uint8Array;
+    try {
+      bytes = await body.transformToByteArray();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "未知错误";
+      throw new Error(`图片 ${candidate.key} 读取失败：${message}`);
+    }
+
+    if (bytes.byteLength === 0) {
+      throw new Error(`图片 ${candidate.key} 读取结果为空`);
+    }
+
     result.push({
       name: candidate.fileName ?? candidate.key.split("/").pop() ?? "post-image.jpg",
       bytes,

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -327,7 +327,7 @@ export function App() {
     setDocumentIcon(activeLogoUrl);
   }, [activeLogoUrl]);
 
-  async function login(account: string, password: string) {
+  async function login(account: string, password: string): Promise<MeResponse> {
     setError("");
     const data = await api<MeResponse>("/api/auth/login", {
       method: "POST",
@@ -336,14 +336,15 @@ export function App() {
     setMe(data);
     if (data.authenticated) {
       if (route.kind === "oauth") {
-        return;
+        return data;
       }
       if (data.user.passwordChangeRequired) {
         navigate({ kind: "login" }, "replace");
-        return;
+        return data;
       }
       navigate(data.needsTenantSelection ? { kind: "tenants" } : { kind: "tenant", tab: activeTab });
     }
+    return data;
   }
 
   function completeRegistration(data: MeResponse) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 import type { TenantSummary } from "@campux/domain";
 import { toast } from "sonner";
-import { api, fileToBase64 } from "@/lib/api";
+import { api } from "@/lib/api";
 import { canAccess, defaultMetadata, navItems } from "@/lib/app-model";
 import { readQueryInt, writeQueryParams } from "@/lib/url-query";
 import type { ActiveBan, AdminTab, AuthenticatedMe, CurrentMembership, MainTab, MeResponse, OAuthAuthorizeClientResponse, Pagination, PostItem, PostsTab, TenantMetadata, UploadedImage } from "@/types/app";
+import { useUploadImages } from "@/hooks/useUploadImages";
 import { LoadingScreen } from "@/features/auth/LoadingScreen";
 import { LoginScreen } from "@/features/auth/LoginScreen";
 import { BannedScreen } from "@/features/auth/BannedScreen";
@@ -89,6 +90,7 @@ export function App() {
   const [adminUserDetailTarget, setAdminUserDetailTarget] = useState<{ userId: string; nonce: number } | null>(null);
   const [error, setError] = useState("");
   const [busy, setBusy] = useState(false);
+  const { uploadingFiles, uploadFiles, removeUploading } = useUploadImages();
 
   const hostTenant = authContext.currentTenant;
   const selectedTenant = me?.authenticated ? me.currentTenant : (hostTenant ?? tenants[0]);
@@ -411,32 +413,16 @@ export function App() {
     await loadTenantData(1);
   }
 
-  async function uploadFiles(files: ArrayLike<File> | null) {
+  async function handleUploadFiles(files: ArrayLike<File> | null) {
     if (!files?.length) {
       return;
     }
 
-    setBusy(true);
-    try {
-      const nextImages: UploadedImage[] = [];
-      for (const file of Array.from(files).slice(0, 9 - uploadedImages.length)) {
-        const previewUrl = await fileToBase64(file);
-        const uploaded = await api<Omit<UploadedImage, "previewUrl">>("/api/uploads/post-images", {
-          method: "POST",
-          body: JSON.stringify({
-            fileName: getUploadFileName(file),
-            contentType: file.type || "application/octet-stream",
-            base64: previewUrl,
-          }),
-        });
-        nextImages.push({ ...uploaded, previewUrl });
-      }
-      setUploadedImages((current) => [...current, ...nextImages]);
-    } catch (caught) {
-      toast.error(caught instanceof Error ? caught.message : "图片上传失败");
-    } finally {
-      setBusy(false);
-    }
+    await uploadFiles(files, uploadedImages, uploadingFiles, (image) => {
+      setUploadedImages((current) =>
+        [...current, image].sort((left, right) => left.sortOrder - right.sortOrder),
+      );
+    });
   }
 
   async function submitPost() {
@@ -539,10 +525,11 @@ export function App() {
       postsPagination={postsPagination}
       anonymous={anonymous}
       uploadedImages={uploadedImages}
+      uploadingFiles={uploadingFiles}
       onActiveTabChange={setActiveTab}
       onAdminTabChange={setAdminSubTab}
       onAnonymousChange={setAnonymous}
-      onFilesSelected={uploadFiles}
+      onFilesSelected={handleUploadFiles}
       onLogout={logout}
       onOpenOps={canOpenOps(me) ? () => navigate({ kind: "ops" }) : undefined}
       onSelectTenant={selectTenant}
@@ -556,6 +543,7 @@ export function App() {
       onPostsPageChange={setPostsPage}
       onRefreshTenantData={() => refreshTenantData(postsPage)}
       onRemoveImage={(key) => setUploadedImages((current) => current.filter((image) => image.key !== key))}
+      onRemoveUploadingFile={removeUploading}
       onSubmitPost={submitPost}
     />
   );
@@ -630,14 +618,6 @@ function pathFromRoute(route: AppRoute) {
     return `/oauth/authorize${route.search}`;
   }
   return `/${route.kind}`;
-}
-
-function getUploadFileName(file: File) {
-  if (file.name) {
-    return file.name;
-  }
-  const extension = file.type.split("/")[1]?.replace(/[^a-zA-Z0-9]/g, "").toLowerCase() || "png";
-  return `pasted-image.${extension}`;
 }
 
 function buildDocumentTitle(route: AppRoute, tenantName?: string, systemRole?: AuthenticatedMe["user"]["systemRole"] | null) {

--- a/apps/web/src/features/auth/LoginScreen.tsx
+++ b/apps/web/src/features/auth/LoginScreen.tsx
@@ -5,7 +5,47 @@ import { api } from "@/lib/api";
 import type { MeResponse } from "@/types/app";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
 import { ThemeModeButton } from "@/features/theme/ThemeModeControl";
+
+const CREDENTIALS_KEY = "campux.loginCredentials.v1";
+
+function readSavedCredentials(): { account: string; password: string } | null {
+  try {
+    const raw = localStorage.getItem(CREDENTIALS_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "account" in parsed &&
+      "password" in parsed &&
+      typeof (parsed as { account: unknown }).account === "string" &&
+      typeof (parsed as { password: unknown }).password === "string"
+    ) {
+      return parsed as { account: string; password: string };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function saveCredentials(account: string, password: string) {
+  try {
+    localStorage.setItem(CREDENTIALS_KEY, JSON.stringify({ account, password }));
+  } catch {
+    // Storage unavailable; login should still work.
+  }
+}
+
+function clearSavedCredentials() {
+  try {
+    localStorage.removeItem(CREDENTIALS_KEY);
+  } catch {
+    // Storage unavailable; login should still work.
+  }
+}
 
 export function LoginScreen({
   hostTenant,
@@ -19,26 +59,53 @@ export function LoginScreen({
   logoUrl: string;
   error: string;
   managementHost: boolean;
-  onLogin: (account: string, password: string) => Promise<void>;
+  onLogin: (account: string, password: string) => Promise<MeResponse>;
   onRegistered: (data: MeResponse) => void;
 }) {
   const allowTestAccounts = import.meta.env.DEV;
   const title = hostTenant?.name ?? "Campux";
   const registerTenantName = hostTenant?.name ?? "Campux";
 
-  const [account, setAccount] = useState(allowTestAccounts ? "10000" : "");
-  const [password, setPassword] = useState(allowTestAccounts ? "campux123" : "");
+  const [savedCredentials] = useState(readSavedCredentials);
+  const [account, setAccount] = useState(() => savedCredentials?.account ?? (allowTestAccounts ? "10000" : ""));
+  const [password, setPassword] = useState(() => savedCredentials?.password ?? (allowTestAccounts ? "campux123" : ""));
+  const [remember, setRemember] = useState(() => savedCredentials !== null);
   const [busy, setBusy] = useState(false);
   const [registerOpen, setRegisterOpen] = useState(false);
+  const [loginError, setLoginError] = useState("");
+  const displayError = loginError || error;
+
+  function handleRememberChange(checked: boolean) {
+    setRemember(checked);
+    if (!checked) {
+      clearSavedCredentials();
+    }
+  }
 
   async function handleSubmit(event: FormEvent) {
     event.preventDefault();
+    setLoginError("");
     setBusy(true);
     try {
-      await onLogin(account, password);
+      const data = await onLogin(account, password);
+      if (data.authenticated && !data.user.passwordChangeRequired && remember) {
+        saveCredentials(account, password);
+      }
+    } catch (caught) {
+      setLoginError(caught instanceof Error ? caught.message : "登录失败，请稍后再试");
     } finally {
       setBusy(false);
     }
+  }
+
+  function handleAccountChange(value: string) {
+    setAccount(value);
+    setLoginError("");
+  }
+
+  function handlePasswordChange(value: string) {
+    setPassword(value);
+    setLoginError("");
   }
 
   return (
@@ -69,10 +136,15 @@ export function LoginScreen({
           <p className="text-lg font-semibold text-slate-950">登录到 Campux</p>
           <p className="mt-2 text-sm leading-6 text-slate-600">输入 QQ 号或邮箱，以及你的账号密码。</p>
           <div className="mt-5 grid gap-3">
-            <Input value={account} placeholder="QQ 号 / 邮箱" onChange={(event) => setAccount(event.target.value)} />
-            <Input value={password} type="password" placeholder="密码" onChange={(event) => setPassword(event.target.value)} />
+            <Input value={account} name="username" autoComplete="username" placeholder="QQ 号 / 邮箱" onChange={(event) => handleAccountChange(event.target.value)} />
+            <Input value={password} name="password" autoComplete="current-password" type="password" placeholder="密码" onChange={(event) => handlePasswordChange(event.target.value)} />
           </div>
-          {error ? <p className="mt-3 text-sm font-medium text-red-600">{error}</p> : null}
+          <div className="mt-3 flex items-center gap-2">
+            <Switch id="remember-credentials" checked={remember} onCheckedChange={handleRememberChange} size="sm" />
+            <label htmlFor="remember-credentials" className="cursor-pointer select-none text-sm text-slate-700">记住账号和密码</label>
+            <span className="text-xs text-slate-400">仅保存在当前浏览器。</span>
+          </div>
+          {displayError ? <p className="mt-3 text-sm font-medium text-red-600">{displayError}</p> : null}
           <Button className="mt-5 w-full font-medium" disabled={busy} type="submit">
             {busy ? "登录中" : "登录"}
           </Button>

--- a/apps/web/src/features/posts/PostPage.tsx
+++ b/apps/web/src/features/posts/PostPage.tsx
@@ -3,7 +3,7 @@ import type { ClipboardEvent } from "react";
 import type { TenantSummary } from "@campux/domain";
 import { ImagePlusIcon, MegaphoneIcon, SendIcon } from "lucide-react";
 import { defaultMetadata } from "@/lib/app-model";
-import type { TenantMetadata, UploadedImage } from "@/types/app";
+import type { TenantMetadata, UploadedImage, UploadingFile } from "@/types/app";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -20,10 +20,12 @@ export function PostPage({
   anonymous,
   selectedTenant,
   uploadedImages,
+  uploadingFiles,
   onPostTextChange,
   onAnonymousChange,
   onFilesSelected,
   onRemoveImage,
+  onRemoveUploadingFile,
   onSubmit,
 }: {
   busy: boolean;
@@ -33,15 +35,30 @@ export function PostPage({
   anonymous: boolean;
   selectedTenant: TenantSummary;
   uploadedImages: UploadedImage[];
+  uploadingFiles: UploadingFile[];
   onPostTextChange: (value: string) => void;
   onAnonymousChange: (value: boolean) => void;
   onFilesSelected: (files: ArrayLike<File> | null) => void;
   onRemoveImage: (key: string) => void;
+  onRemoveUploadingFile: (id: string) => void;
   onSubmit: () => void;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [imageToRemove, setImageToRemove] = useState<UploadedImage | null>(null);
+  const [uploadingToRemove, setUploadingToRemove] = useState<UploadingFile | null>(null);
   const rules = metadata.postRules.length > 0 ? metadata.postRules : defaultMetadata.postRules;
+  const imageItems = [
+    ...uploadingFiles.map((uploading) => ({
+      kind: "uploading" as const,
+      item: uploading,
+      sortOrder: uploading.sortOrder,
+    })),
+    ...uploadedImages.map((image) => ({
+      kind: "uploaded" as const,
+      item: image,
+      sortOrder: image.sortOrder,
+    })),
+  ].sort((left, right) => left.sortOrder - right.sortOrder);
 
   function pasteImages(event: ClipboardEvent<HTMLTextAreaElement>) {
     const files = Array.from(event.clipboardData.items)
@@ -61,6 +78,14 @@ export function PostPage({
     }
     onRemoveImage(imageToRemove.key);
     setImageToRemove(null);
+  }
+
+  function confirmRemoveUploading() {
+    if (!uploadingToRemove) {
+      return;
+    }
+    onRemoveUploadingFile(uploadingToRemove.id);
+    setUploadingToRemove(null);
   }
 
   return (
@@ -84,12 +109,38 @@ export function PostPage({
         />
 
         <div className="mt-3 flex flex-wrap gap-2">
-          {uploadedImages.map((image) => (
-            <button key={image.key} className="h-16 w-16 overflow-hidden rounded-md border border-slate-200 bg-slate-100" onClick={() => setImageToRemove(image)}>
-              <img src={image.previewUrl} alt={image.fileName} className="h-full w-full object-cover" />
-            </button>
-          ))}
-          {uploadedImages.length < 9 ? (
+          {imageItems.map(({ kind, item }) => {
+            if (kind === "uploading") {
+              return (
+                <button
+                  key={item.id}
+                  className="relative h-[70px] w-[70px] overflow-hidden rounded-md border border-slate-200 bg-slate-100"
+                  disabled={item.status === "uploading"}
+                  onClick={() => item.status === "failed" && setUploadingToRemove(item)}
+                >
+                  <img src={item.blobUrl} alt={item.file.name} className="h-full w-full object-cover" />
+                  {item.status === "uploading" ? (
+                    <div className="absolute inset-x-0 bottom-0 h-1 bg-slate-200">
+                      <div className="h-full bg-blue-500 transition-all" style={{ width: `${Math.max(item.progress, 2)}%` }} />
+                    </div>
+                  ) : null}
+                  {item.status === "failed" ? (
+                    <div className="absolute inset-0 flex flex-col items-center justify-center gap-0.5 bg-red-500/35 px-1 text-center text-[11px] font-medium leading-tight text-red-900">
+                      <span>上传失败</span>
+                      <span className="line-clamp-2 max-w-full break-words font-normal">{item.errorMessage || "请重试"}</span>
+                    </div>
+                  ) : null}
+                </button>
+              );
+            }
+
+            return (
+              <button key={item.key} className="h-16 w-16 overflow-hidden rounded-md border border-slate-200 bg-slate-100" onClick={() => setImageToRemove(item)}>
+                <img src={item.previewUrl} alt={item.fileName} className="h-full w-full object-cover" />
+              </button>
+            );
+          })}
+          {uploadedImages.length + uploadingFiles.length < 9 ? (
             <Button
               variant="outline"
               className="h-16 w-16 rounded-md border border-dashed border-slate-300 bg-white p-0 text-slate-500 shadow-none hover:bg-slate-50"
@@ -102,6 +153,7 @@ export function PostPage({
           ) : null}
           <input ref={inputRef} hidden multiple accept="image/*" type="file" onChange={(event) => onFilesSelected(event.target.files)} />
         </div>
+        <p className="mt-2 text-xs leading-5 text-slate-500">最多 9 张图片，单张不超过 10MB。上传失败时点击缩略图可查看原因并移除。</p>
 
         <div className="mt-3 w-fit rounded-md border px-3 py-2 text-sm product-accent-green">
           <div className="flex items-center gap-3">
@@ -155,6 +207,30 @@ export function PostPage({
             </Button>
             <Button variant="destructive" onClick={confirmRemoveImage}>
               删除
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={Boolean(uploadingToRemove)} onOpenChange={(open) => !open && setUploadingToRemove(null)}>
+        <DialogContent className="w-[min(420px,calc(100vw-32px))]">
+          <DialogHeader>
+            <DialogTitle>移除这张图片？</DialogTitle>
+            <DialogDescription>
+              {uploadingToRemove?.status === "failed" ? (uploadingToRemove.errorMessage || "这张图片上传失败，移除后可以重新上传。") : "移除后需要重新选择或粘贴上传。"}
+            </DialogDescription>
+          </DialogHeader>
+          {uploadingToRemove ? (
+            <div className="px-5">
+              <img src={uploadingToRemove.blobUrl} alt={uploadingToRemove.file.name} className="max-h-72 w-full rounded-md border border-slate-200 bg-slate-50 object-contain" />
+            </div>
+          ) : null}
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setUploadingToRemove(null)}>
+              取消
+            </Button>
+            <Button variant="destructive" onClick={confirmRemoveUploading}>
+              移除
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/features/shell/AppShell.tsx
+++ b/apps/web/src/features/shell/AppShell.tsx
@@ -1,4 +1,4 @@
-import type { AdminTab, AuthenticatedMe, MainTab, Pagination, PostItem, PostsTab, TenantMetadata, UploadedImage } from "@/types/app";
+import type { AdminTab, AuthenticatedMe, MainTab, Pagination, PostItem, PostsTab, TenantMetadata, UploadedImage, UploadingFile } from "@/types/app";
 import type { NavItem } from "@/lib/app-model";
 import { AdminPage } from "@/features/admin/AdminPage";
 import { PostPage } from "@/features/posts/PostPage";
@@ -24,6 +24,7 @@ export function AppShell({
   postsPagination,
   anonymous,
   uploadedImages,
+  uploadingFiles,
   onActiveTabChange,
   onAdminTabChange,
   onAnonymousChange,
@@ -41,6 +42,7 @@ export function AppShell({
   onAdminUserDetailTargetConsumed,
   onOpenPostDetailFromAdmin,
   onRemoveImage,
+  onRemoveUploadingFile,
   onSubmitPost,
 }: {
   activeTab: MainTab;
@@ -56,6 +58,7 @@ export function AppShell({
   postsPagination: Pagination;
   anonymous: boolean;
   uploadedImages: UploadedImage[];
+  uploadingFiles: UploadingFile[];
   onActiveTabChange: (tab: MainTab) => void;
   onAdminTabChange: (tab: AdminTab) => void;
   onAnonymousChange: (value: boolean) => void;
@@ -73,6 +76,7 @@ export function AppShell({
   onAdminUserDetailTargetConsumed: () => void;
   onOpenPostDetailFromAdmin: (post: { id: string; displayId: number; status: string }) => void;
   onRemoveImage: (key: string) => void;
+  onRemoveUploadingFile: (id: string) => void;
   onSubmitPost: () => void;
 }) {
   return (
@@ -101,11 +105,13 @@ export function AppShell({
                 anonymous={anonymous}
                 selectedTenant={me.currentTenant}
                 uploadedImages={uploadedImages}
+                uploadingFiles={uploadingFiles}
                 onAnonymousChange={onAnonymousChange}
                 onFilesSelected={onFilesSelected}
                 onPostTextChange={onPostTextChange}
                 onSubmit={onSubmitPost}
                 onRemoveImage={onRemoveImage}
+                onRemoveUploadingFile={onRemoveUploadingFile}
               />
             </TabsContent>
 

--- a/apps/web/src/hooks/useUploadImages.ts
+++ b/apps/web/src/hooks/useUploadImages.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+import type { UploadedImage, UploadingFile } from "@/types/app";
+import { uploadWithProgress } from "@/lib/api";
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_FILE_SIZE_LABEL = "10MB";
+
+export function useUploadImages() {
+  const [uploadingFiles, setUploadingFiles] = useState<UploadingFile[]>([]);
+  const blobUrlsRef = useRef<string[]>([]);
+
+  useEffect(() => {
+    return () => {
+      for (const url of blobUrlsRef.current) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, []);
+
+  function removeUploading(id: string) {
+    setUploadingFiles((current) => {
+      const item = current.find((f) => f.id === id);
+      if (item?.blobUrl) {
+        URL.revokeObjectURL(item.blobUrl);
+        blobUrlsRef.current = blobUrlsRef.current.filter((url) => url !== item.blobUrl);
+      }
+      return current.filter((f) => f.id !== id);
+    });
+  }
+
+  const uploadFiles = useCallback(
+    async (
+      files: ArrayLike<File> | null,
+      uploadedImages: UploadedImage[],
+      existingUploadingFiles: UploadingFile[],
+      onUploaded: (image: UploadedImage) => void,
+    ) => {
+      if (!files?.length) {
+        return;
+      }
+
+      const remainingSlots = Math.max(9 - uploadedImages.length - existingUploadingFiles.length, 0);
+      const fileArray = Array.from(files).slice(0, remainingSlots);
+      if (fileArray.length === 0) {
+        toast.error("最多只能添加 9 张图片");
+        return;
+      }
+
+      const oversized = fileArray.filter((f) => f.size > MAX_FILE_SIZE);
+      if (oversized.length > 0) {
+        toast.error(`${oversized.map((f) => f.name || "图片").join("、")} 超过 ${MAX_FILE_SIZE_LABEL} 限制`);
+      }
+      const validFiles = fileArray.filter((f) => f.size <= MAX_FILE_SIZE);
+      if (validFiles.length === 0) {
+        return;
+      }
+
+      const nextSortOrder =
+        Math.max(
+          -1,
+          ...uploadedImages.map((image) => image.sortOrder),
+          ...existingUploadingFiles.map((file) => file.sortOrder),
+        ) + 1;
+
+      const newEntries: UploadingFile[] = validFiles.map((file, index) => {
+        const blobUrl = URL.createObjectURL(file);
+        blobUrlsRef.current.push(blobUrl);
+        return {
+          id: crypto.randomUUID(),
+          file,
+          blobUrl,
+          progress: 0,
+          status: "uploading" as const,
+          sortOrder: nextSortOrder + index,
+        };
+      });
+
+      setUploadingFiles((current) => [...current, ...newEntries]);
+
+      for (const entry of newEntries) {
+        try {
+          const result = await uploadWithProgress(entry.file, (progress) => {
+            setUploadingFiles((current) =>
+              current.map((f) => (f.id === entry.id ? { ...f, progress } : f)),
+            );
+          });
+          onUploaded({ ...result, previewUrl: result.url, sortOrder: entry.sortOrder });
+          setUploadingFiles((current) => current.filter((f) => f.id !== entry.id));
+          URL.revokeObjectURL(entry.blobUrl);
+          blobUrlsRef.current = blobUrlsRef.current.filter((url) => url !== entry.blobUrl);
+        } catch (caught) {
+          const errorMessage = caught instanceof Error ? caught.message : "图片上传失败";
+          toast.error(errorMessage);
+          setUploadingFiles((current) =>
+            current.map((f) =>
+              f.id === entry.id ? { ...f, status: "failed" as const, errorMessage } : f,
+            ),
+          );
+        }
+      }
+    },
+    [],
+  );
+
+  return {
+    uploadingFiles,
+    uploadFiles,
+    removeUploading,
+  };
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -15,11 +15,55 @@ export async function api<T>(path: string, options: RequestInit = {}) {
   return data as T;
 }
 
-export function fileToBase64(file: File) {
-  return new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(String(reader.result));
-    reader.onerror = () => reject(reader.error);
-    reader.readAsDataURL(file);
+export type UploadImageResponse = {
+  key: string;
+  url: string;
+  fileName: string;
+};
+
+export function uploadWithProgress(
+  file: File,
+  onProgress: (progress: number) => void,
+): Promise<UploadImageResponse> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("POST", "/api/uploads/post-images");
+    xhr.withCredentials = true;
+
+    xhr.upload.addEventListener("progress", (event) => {
+      if (event.lengthComputable) {
+        onProgress((event.loaded / event.total) * 100);
+      }
+    });
+
+    xhr.addEventListener("load", () => {
+      let parsed: UploadImageResponse | { message?: string };
+      try {
+        parsed = JSON.parse(xhr.responseText) as UploadImageResponse | { message?: string };
+      } catch {
+        reject(new Error(xhr.statusText || `上传失败：${xhr.status}`));
+        return;
+      }
+
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(parsed as UploadImageResponse);
+        return;
+      }
+
+      const message = (parsed as { message?: string }).message || `上传失败：${xhr.status}`;
+      reject(new Error(message));
+    });
+
+    xhr.addEventListener("error", () => {
+      reject(new Error("网络错误，图片上传失败"));
+    });
+
+    xhr.addEventListener("abort", () => {
+      reject(new Error("上传已取消"));
+    });
+
+    const formData = new FormData();
+    formData.append("file", file);
+    xhr.send(formData);
   });
 }

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -115,6 +115,17 @@ export type UploadedImage = {
   url: string;
   fileName: string;
   previewUrl: string;
+  sortOrder: number;
+};
+
+export type UploadingFile = {
+  id: string;
+  file: File;
+  blobUrl: string;
+  progress: number;
+  status: "uploading" | "failed";
+  sortOrder: number;
+  errorMessage?: string;
 };
 
 export type PostItem = {

--- a/bun.lock
+++ b/bun.lock
@@ -18,12 +18,14 @@
       "name": "@campux/server",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.812.0",
+        "@aws-sdk/lib-storage": "3.1045.0",
         "@campux/config": "workspace:*",
         "@campux/db": "workspace:*",
         "@campux/domain": "workspace:*",
         "@campux/integrations": "workspace:*",
         "@campux/render": "workspace:*",
         "@fastify/cors": "^11.0.1",
+        "@fastify/multipart": "^9.0.0",
         "@fastify/static": "^9.1.3",
         "@fastify/websocket": "^11.2.0",
         "fastify": "^5.3.3",
@@ -168,6 +170,8 @@
     "@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/token-providers": "3.1041.0", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA=="],
 
     "@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.38", "", { "dependencies": { "@aws-sdk/core": "^3.974.8", "@aws-sdk/nested-clients": "^3.997.6", "@aws-sdk/types": "^3.973.8", "@smithy/property-provider": "^4.2.14", "@smithy/shared-ini-file-loader": "^4.4.9", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw=="],
+
+    "@aws-sdk/lib-storage": ["@aws-sdk/lib-storage@3.1045.0", "", { "dependencies": { "@smithy/middleware-endpoint": "^4.4.32", "@smithy/protocol-http": "^5.3.14", "@smithy/smithy-client": "^4.12.13", "@smithy/types": "^4.14.1", "buffer": "5.6.0", "events": "3.3.0", "stream-browserify": "3.0.0", "tslib": "^2.6.2" }, "peerDependencies": { "@aws-sdk/client-s3": "^3.1045.0" } }, "sha512-F7dp2ST/83Iz6JTMMmUYEXxg7R1JDewfvzJeWWiDTwe0vLsg67JTN7OsBe6G8DWYbLQ+EyPWkyc3oFnxOjCVfg=="],
 
     "@aws-sdk/middleware-bucket-endpoint": ["@aws-sdk/middleware-bucket-endpoint@3.972.10", "", { "dependencies": { "@aws-sdk/types": "^3.973.8", "@aws-sdk/util-arn-parser": "^3.972.3", "@smithy/node-config-provider": "^4.3.14", "@smithy/protocol-http": "^5.3.14", "@smithy/types": "^4.14.1", "@smithy/util-config-provider": "^4.2.2", "tslib": "^2.6.2" } }, "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA=="],
 
@@ -359,7 +363,11 @@
 
     "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.5", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A=="],
 
+    "@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
+
     "@fastify/cors": ["@fastify/cors@11.2.0", "", { "dependencies": { "fastify-plugin": "^5.0.0", "toad-cache": "^3.7.0" } }, "sha512-LbLHBuSAdGdSFZYTLVA3+Ch2t+sA6nq3Ejc6XLAKiQ6ViS2qFnvicpj0htsx03FyYeLs04HfRNBsz/a8SvbcUw=="],
+
+    "@fastify/deepmerge": ["@fastify/deepmerge@3.2.1", "", {}, "sha512-N5Oqvltoa2r9z1tbx4xjky0oRR60v+T47Ic4J1ukoVQcptLOrIdRnCSdTGmOmajZuHVKlTnfcmrjyqsGEW1ztA=="],
 
     "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
 
@@ -368,6 +376,8 @@
     "@fastify/forwarded": ["@fastify/forwarded@3.0.1", "", {}, "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw=="],
 
     "@fastify/merge-json-schemas": ["@fastify/merge-json-schemas@0.2.1", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A=="],
+
+    "@fastify/multipart": ["@fastify/multipart@9.4.0", "", { "dependencies": { "@fastify/busboy": "^3.0.0", "@fastify/deepmerge": "^3.0.0", "@fastify/error": "^4.0.0", "fastify-plugin": "^5.0.0", "secure-json-parse": "^4.0.0" } }, "sha512-Z404bzZeLSXTBmp/trCBuoVFX28pM7rhv849Q5TsbTFZHuk1lc4QjQITTPK92DKVpXmNtJXeHSSc7GYvqFpxAQ=="],
 
     "@fastify/proxy-addr": ["@fastify/proxy-addr@5.1.0", "", { "dependencies": { "@fastify/forwarded": "^3.0.0", "ipaddr.js": "^2.1.0" } }, "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw=="],
 
@@ -899,6 +909,8 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.29", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ=="],
 
     "birpc": ["birpc@2.9.0", "", {}, "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw=="],
@@ -912,6 +924,8 @@
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
+
+    "buffer": ["buffer@5.6.0", "", { "dependencies": { "base64-js": "^1.0.2", "ieee754": "^1.1.4" } }, "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
@@ -1071,6 +1085,8 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
@@ -1192,6 +1208,8 @@
     "human-signals": ["human-signals@8.0.1", "", {}, "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -1579,6 +1597,8 @@
 
     "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
 
+    "stream-browserify": ["stream-browserify@3.0.0", "", { "dependencies": { "inherits": "~2.0.4", "readable-stream": "^3.5.0" } }, "sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA=="],
+
     "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
 
     "strict-event-emitter": ["strict-event-emitter@0.5.1", "", {}, "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ=="],
@@ -1730,6 +1750,8 @@
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
+
+    "@aws-sdk/lib-storage/@smithy/types": ["@smithy/types@4.14.2", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 


### PR DESCRIPTION
## 改动内容

本次 PR 包含两部分改动：

1. 优化登录体验
   - 登录失败时在登录页内展示明确错误提示，不再只依赖 toast。
   - 增加“记住密码”选项，仅在登录成功且不需要强制改密时保存到当前浏览器。
   - 登录失败不会覆盖已保存的账号密码。
   - 关闭“记住密码”会主动清除本地保存的凭据。
   - localStorage 读写增加 try/catch，避免 QQ 内置浏览器等受限环境影响登录流程。

2. 改造帖子图片上传
   - 将图片上传从 base64 JSON 改为 multipart/form-data 二进制上传。
   - 使用 XMLHttpRequest 支持上传进度展示。
   - 服务端使用 Fastify multipart 和 S3/MinIO 流式上传，降低内存占用。
   - 保留旧版 base64 JSON 上传兼容，避免旧客户端直接不可用。
   - 单张图片限制调整为 10MB，并在前端展示限制提示。
   - 上传失败时展示具体错误原因。
   - 多图上传时按用户选择顺序展示，不再按上传完成顺序排序。
   - 发布读取图片时增加 tenant key 校验、对象大小检查和明确错误提示。

## 背景

原先图片通过 base64 over JSON 上传，会带来约 33% 的体积膨胀，大文件容易触发请求体限制，也无法显示上传进度。改为 multipart 二进制上传后，可以减少请求体积、支持进度反馈，并降低前后端内存压力。

同时，登录页在失败场景下缺少页面内反馈，QQ 内置浏览器等环境里用户容易误以为没有响应，因此补充了更明确的登录错误展示和可选的本地凭据记忆能力。

## 兼容性

- 新客户端使用 multipart/form-data 上传图片。
- 旧客户端仍可继续调用 `/api/uploads/post-images` 并提交 `fileName`、`contentType`、`base64` JSON payload。
- 服务端会对新旧两种上传方式统一执行图片类型校验和 10MB 限制。

## 验证

已执行：

```bash
bun --cwd apps/web typecheck
bun --cwd apps/server typecheck