### PR TITLE
fix: route review group notifications by bot

### DIFF
--- a/apps/server/src/routes/admin.ts
+++ b/apps/server/src/routes/admin.ts
@@ -58,6 +58,7 @@ const botCreateSchema = z.object({
   qqUin: z.string().regex(/^\d+$/, "Bot QQ 必须是数字"),
   displayName: z.string().min(1).max(80),
   reviewGroupId: z.string().trim().max(40).optional(),
+  reviewNotificationEnabled: z.boolean().default(false),
   enabled: z.boolean().default(true),
   createPublishTarget: z.boolean().default(true),
 });
@@ -74,6 +75,7 @@ const botPatchSchema = z.object({
   displayName: z.string().trim().min(1).max(80).optional(),
   enabled: z.boolean().optional(),
   reviewGroupId: z.string().trim().max(40).nullable().optional(),
+  reviewNotificationEnabled: z.boolean().optional(),
   userMessageReply: z.string().trim().min(1).max(1000).optional(),
   userMessageReplyCooldownSeconds: z.number().int().min(0).max(86_400).optional(),
   reviewGroupMessageReply: z.string().trim().min(1).max(1000).optional(),
@@ -546,31 +548,46 @@ export function registerAdminRoutes(app: FastifyInstance, queue: RuntimeQueue, o
       return reply.code(409).send({ message: "这个机器人 QQ 已经绑定到其他校园墙" });
     }
 
-    const bot = await prisma.botAccount.create({
-      data: {
-        tenantId: context.selectedTenant.id,
-        qqUin: BigInt(body.qqUin),
-        displayName: body.displayName,
-        reviewGroupId: body.reviewGroupId?.trim() || null,
-        enabled: body.enabled,
-        ...(body.createPublishTarget
-          ? {
-              publishTargets: {
-                create: {
-                  tenantId: context.selectedTenant.id,
-                  displayName: body.displayName,
-                  enabled: true,
-                  required: false,
-                  publishDelaySeconds: defaultPublishIntervalSeconds,
+    const bot = await prisma.$transaction(async (tx) => {
+      if (body.reviewNotificationEnabled) {
+        await tx.botAccount.updateMany({
+          where: {
+            tenantId: context.selectedTenant.id,
+            reviewNotificationEnabled: true,
+          },
+          data: {
+            reviewNotificationEnabled: false,
+          },
+        });
+      }
+
+      return tx.botAccount.create({
+        data: {
+          tenantId: context.selectedTenant.id,
+          qqUin: BigInt(body.qqUin),
+          displayName: body.displayName,
+          reviewGroupId: body.reviewGroupId?.trim() || null,
+          reviewNotificationEnabled: body.reviewNotificationEnabled,
+          enabled: body.enabled,
+          ...(body.createPublishTarget
+            ? {
+                publishTargets: {
+                  create: {
+                    tenantId: context.selectedTenant.id,
+                    displayName: body.displayName,
+                    enabled: true,
+                    required: false,
+                    publishDelaySeconds: defaultPublishIntervalSeconds,
+                  },
                 },
-              },
-            }
-          : {}),
-      },
-      include: {
-        sessions: true,
-        publishTargets: true,
-      },
+              }
+            : {}),
+        },
+        include: {
+          sessions: true,
+          publishTargets: true,
+        },
+      });
     });
 
     await writeAuditLog({
@@ -583,6 +600,7 @@ export function registerAdminRoutes(app: FastifyInstance, queue: RuntimeQueue, o
         qqUin: body.qqUin,
         displayName: body.displayName,
         reviewGroupId: body.reviewGroupId?.trim() || null,
+        reviewNotificationEnabled: body.reviewNotificationEnabled,
       },
     });
 
@@ -605,23 +623,39 @@ export function registerAdminRoutes(app: FastifyInstance, queue: RuntimeQueue, o
       return reply.code(404).send({ message: "Bot 账号不存在" });
     }
 
-    const updated = await prisma.botAccount.update({
-      where: {
-        id: bot.id,
-      },
-      data: {
-        ...(body.displayName === undefined ? {} : { displayName: body.displayName }),
-        ...(body.enabled === undefined ? {} : { enabled: body.enabled }),
-        ...(body.reviewGroupId === undefined ? {} : { reviewGroupId: body.reviewGroupId?.trim() || null }),
-        ...(body.userMessageReply === undefined ? {} : { userMessageReply: body.userMessageReply }),
-        ...(body.userMessageReplyCooldownSeconds === undefined ? {} : { userMessageReplyCooldownSeconds: body.userMessageReplyCooldownSeconds }),
-        ...(body.reviewGroupMessageReply === undefined ? {} : { reviewGroupMessageReply: body.reviewGroupMessageReply }),
-        ...(body.publishTextTemplate === undefined ? {} : { publishTextTemplate: body.publishTextTemplate }),
-      },
-      include: {
-        sessions: true,
-        publishTargets: true,
-      },
+    const updated = await prisma.$transaction(async (tx) => {
+      if (body.reviewNotificationEnabled === true) {
+        await tx.botAccount.updateMany({
+          where: {
+            tenantId: context.selectedTenant.id,
+            id: { not: bot.id },
+            reviewNotificationEnabled: true,
+          },
+          data: {
+            reviewNotificationEnabled: false,
+          },
+        });
+      }
+
+      return tx.botAccount.update({
+        where: {
+          id: bot.id,
+        },
+        data: {
+          ...(body.displayName === undefined ? {} : { displayName: body.displayName }),
+          ...(body.enabled === undefined ? {} : { enabled: body.enabled }),
+          ...(body.reviewGroupId === undefined ? {} : { reviewGroupId: body.reviewGroupId?.trim() || null }),
+          ...(body.reviewNotificationEnabled === undefined ? {} : { reviewNotificationEnabled: body.reviewNotificationEnabled }),
+          ...(body.userMessageReply === undefined ? {} : { userMessageReply: body.userMessageReply }),
+          ...(body.userMessageReplyCooldownSeconds === undefined ? {} : { userMessageReplyCooldownSeconds: body.userMessageReplyCooldownSeconds }),
+          ...(body.reviewGroupMessageReply === undefined ? {} : { reviewGroupMessageReply: body.reviewGroupMessageReply }),
+          ...(body.publishTextTemplate === undefined ? {} : { publishTextTemplate: body.publishTextTemplate }),
+        },
+        include: {
+          sessions: true,
+          publishTargets: true,
+        },
+      });
     });
 
     await writeAuditLog({
@@ -1163,6 +1197,7 @@ function toBotAccount(
     displayName: string;
     enabled: boolean;
     reviewGroupId: string | null;
+    reviewNotificationEnabled: boolean;
     connectionToken: string;
     publishTextTemplate: Prisma.JsonValue;
     userMessageReply: string;
@@ -1196,6 +1231,7 @@ function toBotAccount(
     displayName: bot.displayName,
     enabled: bot.enabled,
     reviewGroupId: bot.reviewGroupId,
+    reviewNotificationEnabled: bot.reviewNotificationEnabled,
     connectionToken: bot.connectionToken,
     publishTextTemplate: normalizePublishTextTemplate(bot.publishTextTemplate),
     userMessageReply: bot.userMessageReply,

--- a/apps/server/src/runtime/notification-routing.test.ts
+++ b/apps/server/src/runtime/notification-routing.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { selectReviewNotificationBot } from "./notification-routing";
+
+const baseTime = new Date("2026-05-01T00:00:00.000Z");
+
+function bot(overrides: Partial<Parameters<typeof selectReviewNotificationBot>[0][number]> & { id: string }) {
+  return {
+    enabled: true,
+    reviewGroupId: "10000",
+    reviewNotificationEnabled: false,
+    createdAt: baseTime,
+    ...overrides,
+  };
+}
+
+describe("selectReviewNotificationBot", () => {
+  test("does not choose bots that have no explicit review notification switch", () => {
+    expect(selectReviewNotificationBot([
+      bot({ id: "wall-a" }),
+      bot({ id: "wall-b" }),
+    ])).toBeNull();
+  });
+
+  test("chooses only the enabled bot with reviewNotificationEnabled", () => {
+    expect(selectReviewNotificationBot([
+      bot({ id: "wall-a", reviewNotificationEnabled: false }),
+      bot({ id: "wall-b", reviewNotificationEnabled: true }),
+    ])?.id).toBe("wall-b");
+  });
+
+  test("ignores disabled bots and bots without review group", () => {
+    expect(selectReviewNotificationBot([
+      bot({ id: "disabled", reviewNotificationEnabled: true, enabled: false }),
+      bot({ id: "no-group", reviewNotificationEnabled: true, reviewGroupId: null }),
+      bot({ id: "active", reviewNotificationEnabled: true }),
+    ])?.id).toBe("active");
+  });
+
+  test("uses the oldest bot if legacy data accidentally has more than one sender", () => {
+    expect(selectReviewNotificationBot([
+      bot({ id: "newer", reviewNotificationEnabled: true, createdAt: new Date(baseTime.getTime() + 1000) }),
+      bot({ id: "older", reviewNotificationEnabled: true, createdAt: baseTime }),
+    ])?.id).toBe("older");
+  });
+});

--- a/apps/server/src/runtime/notification-routing.ts
+++ b/apps/server/src/runtime/notification-routing.ts
@@ -1,0 +1,14 @@
+export type ReviewNotificationBot = {
+  id: string;
+  enabled: boolean;
+  reviewGroupId: string | null;
+  reviewNotificationEnabled: boolean;
+  createdAt: Date;
+};
+
+export function selectReviewNotificationBot<T extends ReviewNotificationBot>(bots: T[]): T | null {
+  return [...bots]
+    .filter((bot) => bot.enabled && Boolean(bot.reviewGroupId) && bot.reviewNotificationEnabled)
+    .sort((left, right) => left.createdAt.getTime() - right.createdAt.getTime())
+    [0] ?? null;
+}

--- a/apps/server/src/runtime/onebot.ts
+++ b/apps/server/src/runtime/onebot.ts
@@ -20,6 +20,7 @@ import type { RuntimeQueue } from "./queue";
 import { checkAndUpdateQZoneSession } from "../lib/qzone-cookies";
 import { pollQZoneQrLogin, startQZoneQrLogin } from "../lib/qzone-login";
 import { resumePublishAttemptsWaitingForCookies } from "./publishing";
+import { selectReviewNotificationBot } from "./notification-routing";
 
 type OneBotConnection = {
   socket: WebSocketLike;
@@ -149,15 +150,10 @@ export class OneBotRuntime {
       return;
     }
 
-    const bots = await prisma.botAccount.findMany({
-      where: {
-        tenantId: post.tenantId,
-        enabled: true,
-        reviewGroupId: {
-          not: null,
-        },
-      },
-    });
+    const bot = await this.findTenantReviewNotificationBot(post.tenantId);
+    if (!bot?.reviewGroupId) {
+      return;
+    }
 
     const attachments = Array.isArray(post.attachments) ? post.attachments : [];
     const imageCount = attachments.filter((a: any) => a.kind === "image").length;
@@ -189,14 +185,9 @@ export class OneBotRuntime {
           ]
         : lines.join("\n");
 
-    for (const bot of bots) {
-      if (!bot.reviewGroupId) {
-        continue;
-      }
-      await this.sendGroupMessage(bot.qqUin.toString(), bot.reviewGroupId, message).catch((error) => {
-        this.logger.warn({ error, botQqUin: bot.qqUin.toString(), groupId: bot.reviewGroupId }, "failed to notify review group");
-      });
-    }
+    await this.sendGroupMessage(bot.qqUin.toString(), bot.reviewGroupId, message).catch((error) => {
+      this.logger.warn({ error, botQqUin: bot.qqUin.toString(), groupId: bot.reviewGroupId }, "failed to notify review group");
+    });
   }
 
   async notifyPostCancelled(postId: string) {
@@ -211,7 +202,7 @@ export class OneBotRuntime {
     if (!post) {
       return;
     }
-    await this.broadcastReviewGroup(post.tenantId, `稿件已取消：#${post.displayId}`);
+    await this.sendTenantReviewNotification(post.tenantId, `稿件已取消：#${post.displayId}`);
   }
 
   async notifyPostRecallRequested(postId: string) {
@@ -242,7 +233,7 @@ export class OneBotRuntime {
       `理由：${readRecallReason(post.logs[0]?.comment) ?? "未填写"}`,
       "审核员或管理员可在稿件页面同意撤回；同意后系统会把每个 QZone 发布目标设置为仅自己可见。",
     ];
-    await this.broadcastReviewGroup(post.tenantId, lines.join("\n"));
+    await this.sendTenantReviewNotification(post.tenantId, lines.join("\n"));
   }
 
   async notifyPostRecalled(postId: string, targetCount: number, opts?: { skipAuthor?: boolean }) {
@@ -258,7 +249,7 @@ export class OneBotRuntime {
       return;
     }
     const groupSuffix = opts?.skipAuthor ? "\n（静默撤回，未通知作者）" : "";
-    await this.broadcastReviewGroup(post.tenantId, `稿件已撤回：#${post.displayId}\n已处理发布目标：${targetCount} 个${groupSuffix}`);
+    await this.sendTenantReviewNotification(post.tenantId, `稿件已撤回：#${post.displayId}\n已处理发布目标：${targetCount} 个${groupSuffix}`);
 
     if (opts?.skipAuthor) {
       return;
@@ -292,7 +283,7 @@ export class OneBotRuntime {
     if (!post) {
       return;
     }
-    await this.broadcastReviewGroup(post.tenantId, `撤回申请已拒绝：#${post.displayId}\n状态已恢复为已发表。\n理由：${reason}`);
+    await this.sendTenantReviewNotification(post.tenantId, `撤回申请已拒绝：#${post.displayId}\n状态已恢复为已发表。\n理由：${reason}`);
 
     const bots = await prisma.botAccount.findMany({
       where: {
@@ -324,7 +315,7 @@ export class OneBotRuntime {
       `稿件撤回失败：#${post.displayId}`,
       ...failed.map((result) => `${result.targetName}${result.qzoneTid ? ` / ${result.qzoneTid}` : ""}：${result.message}`),
     ];
-    await this.broadcastReviewGroup(post.tenantId, lines.join("\n"));
+    await this.sendTenantReviewNotification(post.tenantId, lines.join("\n"));
   }
 
   async notifyReviewResult(postId: string, status: "approved" | "rejected", comment?: string | null) {
@@ -373,11 +364,18 @@ export class OneBotRuntime {
       where: {
         id: targetId,
       },
+      include: {
+        botAccount: true,
+      },
     });
     if (!post) {
       return;
     }
-    await this.broadcastReviewGroup(post.tenantId, `已成功发表：#${post.displayId}${target ? `\n目标：${target.displayName}` : ""}\n外部 ID：${externalId}`);
+    if (!target) {
+      await this.sendTenantReviewNotification(post.tenantId, `已成功发表：#${post.displayId}\n外部 ID：${externalId}`);
+      return;
+    }
+    await this.sendBotReviewGroupMessage(target.botAccount, `已成功发表：#${post.displayId}\n目标：${target.displayName}\n外部 ID：${externalId}`, "failed to notify publish succeeded");
   }
 
   async notifyPublishFailed(postId: string, targetId: string, message: string, options?: { needsLogin?: boolean; nextRunAt?: Date | null }) {
@@ -407,7 +405,11 @@ export class OneBotRuntime {
       options?.needsLogin ? "请在群内发送 #登录 或 #扫码登录 重新登录后，再重试发布。" : null,
       options?.nextRunAt ? `下次重试：${formatDateTime(options.nextRunAt)}` : null,
     ].filter((line): line is string => Boolean(line));
-    await this.broadcastReviewGroup(post.tenantId, lines.join("\n"));
+    if (target) {
+      await this.sendBotReviewGroupMessage(target.botAccount, lines.join("\n"), "failed to notify publish failed");
+    } else {
+      await this.sendTenantReviewNotification(post.tenantId, lines.join("\n"));
+    }
   }
 
   async notifyPublishWaitingForCookies(postId: string, targetId: string, message: string) {
@@ -436,7 +438,11 @@ export class OneBotRuntime {
       `原因：${message}`,
       "系统不会继续发布这条稿件，直到 QZone cookies 检测可用；重新登录或自动刷新成功后会自动恢复队列。",
     ].filter((line): line is string => Boolean(line));
-    await this.broadcastReviewGroup(post.tenantId, lines.join("\n"));
+    if (target) {
+      await this.sendBotReviewGroupMessage(target.botAccount, lines.join("\n"), "failed to notify publish waiting for cookies");
+    } else {
+      await this.sendTenantReviewNotification(post.tenantId, lines.join("\n"));
+    }
   }
 
   async notifyQZoneCookiesInvalid(botAccountId: string, message: string, options?: { autoRefreshError?: string | null }) {
@@ -575,7 +581,15 @@ export class OneBotRuntime {
     });
   }
 
-  async broadcastReviewGroup(tenantId: string, message: unknown) {
+  async sendTenantReviewNotification(tenantId: string, message: unknown) {
+    const bot = await this.findTenantReviewNotificationBot(tenantId);
+    if (!bot) {
+      return;
+    }
+    await this.sendBotReviewGroupMessage(bot, message, "failed to send tenant review notification");
+  }
+
+  private async findTenantReviewNotificationBot(tenantId: string) {
     const bots = await prisma.botAccount.findMany({
       where: {
         tenantId,
@@ -583,16 +597,26 @@ export class OneBotRuntime {
         reviewGroupId: {
           not: null,
         },
+        reviewNotificationEnabled: true,
+      },
+      orderBy: {
+        createdAt: "asc",
       },
     });
-    for (const bot of bots) {
-      if (!bot.reviewGroupId) {
-        continue;
-      }
-      await this.sendGroupMessage(bot.qqUin.toString(), bot.reviewGroupId, message).catch((error) => {
-        this.logger.warn({ error, botQqUin: bot.qqUin.toString(), groupId: bot.reviewGroupId }, "failed to broadcast review group message");
-      });
+    return selectReviewNotificationBot(bots);
+  }
+
+  private async sendBotReviewGroupMessage(
+    bot: { qqUin: bigint; displayName?: string; reviewGroupId: string | null },
+    message: unknown,
+    logMessage: string,
+  ) {
+    if (!bot.reviewGroupId) {
+      return;
     }
+    await this.sendGroupMessage(bot.qqUin.toString(), bot.reviewGroupId, message).catch((error) => {
+      this.logger.warn({ error, botQqUin: bot.qqUin.toString(), groupId: bot.reviewGroupId }, logMessage);
+    });
   }
 
   async callAction(botQqUin: string, action: string, params: Record<string, unknown>, timeoutMs = 8_000) {

--- a/apps/web/src/features/admin/AdminPage.tsx
+++ b/apps/web/src/features/admin/AdminPage.tsx
@@ -571,7 +571,7 @@ export function AdminPage({
 
   async function updateBotConfig(
     botId: string,
-    patch: Partial<Pick<AdminBotAccount, "displayName" | "enabled" | "reviewGroupId" | "userMessageReply" | "userMessageReplyCooldownSeconds" | "reviewGroupMessageReply">>,
+    patch: Partial<Pick<AdminBotAccount, "displayName" | "enabled" | "reviewGroupId" | "reviewNotificationEnabled" | "userMessageReply" | "userMessageReplyCooldownSeconds" | "reviewGroupMessageReply">>,
   ) {
     setBusy(true);
     try {
@@ -1733,7 +1733,7 @@ function BotsPanel({
   onDelete: (id: string) => void;
   onUpdateConfig: (
     botId: string,
-    patch: Partial<Pick<AdminBotAccount, "displayName" | "enabled" | "reviewGroupId" | "userMessageReply" | "userMessageReplyCooldownSeconds" | "reviewGroupMessageReply">>,
+    patch: Partial<Pick<AdminBotAccount, "displayName" | "enabled" | "reviewGroupId" | "reviewNotificationEnabled" | "userMessageReply" | "userMessageReplyCooldownSeconds" | "reviewGroupMessageReply">>,
   ) => void;
   onRefresh: () => void;
 }) {
@@ -1898,13 +1898,14 @@ function BotConfigEditor({
 }: {
   bot: AdminBotAccount;
   busy: boolean;
-  onSave: (patch: Partial<Pick<AdminBotAccount, "displayName" | "enabled" | "reviewGroupId" | "userMessageReply" | "userMessageReplyCooldownSeconds" | "reviewGroupMessageReply">>) => void;
+  onSave: (patch: Partial<Pick<AdminBotAccount, "displayName" | "enabled" | "reviewGroupId" | "reviewNotificationEnabled" | "userMessageReply" | "userMessageReplyCooldownSeconds" | "reviewGroupMessageReply">>) => void;
 }) {
   const [displayName, setDisplayName] = useState(bot.displayName);
   const [reviewGroupId, setReviewGroupId] = useState(bot.reviewGroupId ?? "");
   const [userMessageReply, setUserMessageReply] = useState(bot.userMessageReply);
   const [userMessageReplyCooldownSeconds, setUserMessageReplyCooldownSeconds] = useState(String(bot.userMessageReplyCooldownSeconds));
   const [reviewGroupMessageReply, setReviewGroupMessageReply] = useState(bot.reviewGroupMessageReply);
+  const [reviewNotificationEnabled, setReviewNotificationEnabled] = useState(bot.reviewNotificationEnabled);
   const [enabled, setEnabled] = useState(bot.enabled);
 
   useEffect(() => {
@@ -1913,8 +1914,9 @@ function BotConfigEditor({
     setUserMessageReply(bot.userMessageReply);
     setUserMessageReplyCooldownSeconds(String(bot.userMessageReplyCooldownSeconds));
     setReviewGroupMessageReply(bot.reviewGroupMessageReply);
+    setReviewNotificationEnabled(bot.reviewNotificationEnabled);
     setEnabled(bot.enabled);
-  }, [bot.displayName, bot.reviewGroupId, bot.userMessageReply, bot.userMessageReplyCooldownSeconds, bot.reviewGroupMessageReply, bot.enabled]);
+  }, [bot.displayName, bot.reviewGroupId, bot.userMessageReply, bot.userMessageReplyCooldownSeconds, bot.reviewGroupMessageReply, bot.reviewNotificationEnabled, bot.enabled]);
 
   const trimmedDisplayName = displayName.trim();
   const trimmedReviewGroupId = reviewGroupId.trim();
@@ -1926,6 +1928,7 @@ function BotConfigEditor({
     || trimmedUserMessageReply !== bot.userMessageReply
     || normalizedCooldownSeconds !== bot.userMessageReplyCooldownSeconds
     || trimmedReviewGroupMessageReply !== bot.reviewGroupMessageReply
+    || reviewNotificationEnabled !== bot.reviewNotificationEnabled
     || enabled !== bot.enabled;
 
   return (
@@ -1946,6 +1949,7 @@ function BotConfigEditor({
               userMessageReply: trimmedUserMessageReply,
               userMessageReplyCooldownSeconds: normalizedCooldownSeconds,
               reviewGroupMessageReply: trimmedReviewGroupMessageReply,
+              reviewNotificationEnabled,
               enabled,
             })
           }
@@ -1956,10 +1960,19 @@ function BotConfigEditor({
       <div className="mt-2 grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]">
         <Input className="bg-white" placeholder="显示名" value={displayName} onChange={(event) => setDisplayName(event.target.value)} />
         <Input className="bg-white" placeholder="审核群号，可留空" value={reviewGroupId} onChange={(event) => setReviewGroupId(event.target.value.replace(/\D/g, ""))} />
-        <label className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-bold text-slate-600">
-          <input type="checkbox" checked={enabled} onChange={(event) => setEnabled(event.target.checked)} />
-          启用
-        </label>
+        <div className="grid gap-2">
+          <label className="inline-flex items-center gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-bold text-slate-600">
+            <input type="checkbox" checked={enabled} onChange={(event) => setEnabled(event.target.checked)} />
+            启用
+          </label>
+          <label className="inline-flex items-start gap-2 rounded-md border border-slate-200 bg-white px-3 py-2 text-sm font-bold text-slate-600">
+            <input className="mt-1" type="checkbox" checked={reviewNotificationEnabled} onChange={(event) => setReviewNotificationEnabled(event.target.checked)} />
+            <span>
+              发送稿件审核通知
+              <span className="block text-[11px] font-semibold text-slate-400">新稿件、撤回等租户全局通知仅由打开此项的墙号发送；保存后会自动关闭其他墙号。</span>
+            </span>
+          </label>
+        </div>
       </div>
       <div className="mt-2 grid gap-2 md:grid-cols-[minmax(0,1fr)_180px]">
         <div className="grid gap-2">
@@ -2252,6 +2265,7 @@ function PublishPanel({
                       displayName: target.botAccount.displayName,
                       enabled: target.botAccount.enabled,
                       reviewGroupId: null,
+                      reviewNotificationEnabled: false,
                       connectionToken: target.botAccount.connectionToken,
                       publishTextTemplate: target.botAccount.publishTextTemplate,
                       userMessageReply: "",

--- a/apps/web/src/types/app.ts
+++ b/apps/web/src/types/app.ts
@@ -293,6 +293,7 @@ export type AdminBotAccount = {
   displayName: string;
   enabled: boolean;
   reviewGroupId: string | null;
+  reviewNotificationEnabled: boolean;
   connectionToken: string;
   publishTextTemplate: PublishTextTemplate;
   userMessageReply: string;

--- a/packages/db/prisma/migrations/20260522120000_add_bot_review_notification_sender/migration.sql
+++ b/packages/db/prisma/migrations/20260522120000_add_bot_review_notification_sender/migration.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "BotAccount"
+ADD COLUMN "reviewNotificationEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+WITH ranked_review_bots AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (PARTITION BY "tenantId" ORDER BY "createdAt" ASC, id ASC) AS rn
+  FROM "BotAccount"
+  WHERE enabled = true AND "reviewGroupId" IS NOT NULL
+)
+UPDATE "BotAccount" AS bot
+SET "reviewNotificationEnabled" = true
+FROM ranked_review_bots AS ranked
+WHERE bot.id = ranked.id AND ranked.rn = 1;
+
+CREATE UNIQUE INDEX "BotAccount_one_review_notification_sender_per_tenant"
+ON "BotAccount"("tenantId")
+WHERE "reviewNotificationEnabled" = true;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -257,6 +257,7 @@ model BotAccount {
   displayName    String
   enabled        Boolean         @default(true)
   reviewGroupId  String?
+  reviewNotificationEnabled Boolean @default(false)
   connectionToken String          @default(uuid())
   publishTextTemplate Json        @default("{\"includePostId\":true,\"includeAuthorMention\":false,\"includeLinks\":false,\"customText\":\"\"}")
   userMessageReply String         @default("发送 #注册账号 可以用当前 QQ 注册本校园墙账号。\n发送 #重置密码 可以重置你的登录密码。")


### PR DESCRIPTION
## Summary
- add a per-bot `reviewNotificationEnabled` switch for tenant-wide manuscript/review-group notifications
- enforce one review notification sender per tenant via migration + admin update logic
- route publish/cookies-related review-group notices through the bot account tied to the publish target instead of broadcasting to every bot in the same review group
- expose the switch in the bot admin panel

## Verification
- `bun test apps/server/src/runtime/notification-routing.test.ts`
- `bun run typecheck`
- `bun run build`
